### PR TITLE
Read away trash coming before slave id

### DIFF
--- a/arduino-modbus-rtu-tcp-gateway/03-modbus-rtu.ino
+++ b/arduino-modbus-rtu-tcp-gateway/03-modbus-rtu.ino
@@ -127,7 +127,13 @@ void recvSerial() {
   static byte serialIn[MODBUS_SIZE];
   while (mySerial.available() > 0) {
     byte b = mySerial.read();
-    if (rxNdx < MODBUS_SIZE) {
+    if (rxNdx == 0 && queueData[0] != b) {
+      if(recvMicroTimer.isOver())
+        break;
+      // wait a bit to the buffer to clean up
+      recvMicroTimer.sleep(charTimeOut());  
+    }
+    else if (rxNdx < MODBUS_SIZE) {
       serialIn[rxNdx] = b;
       rxNdx++;
     }  // if frame longer than maximum allowed, CRC will fail and data.errorCnt[ERROR_RTU] will be recorded down the road


### PR DESCRIPTION
Thanks for this awesome piece of software. I had bit of hard time getting it working with generic rs485 adapter(with manual flow control) for arduino.
For some reason there was some random trash in bus coming before the actual content started.
Here I added check where the actual data starts and it reads the trash away before it.

Hope this will help some one.